### PR TITLE
Add CI status badge, tweak Figma badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Figma Design System](https://img.shields.io/badge/Figma-Design-pink.svg?style=for-the-badge&logo=figma)](https://www.figma.com/file/iJbFMd9ZzU2U9iQZ0nk72t/Fractal-Foundations)
+[![Figma Design System](https://img.shields.io/badge/Figma-Design%20System-10A171.svg?style=for-the-badge-small&logo=figma)](https://www.figma.com/file/iJbFMd9ZzU2U9iQZ0nk72t/Fractal-Foundations)&nbsp;
+![CI status](https://github.com/petedoyle/compose-exploration/actions/workflows/ci.yml/badge.svg)&nbsp;
 
 # About
 A place for ✨👨‍🔬 personal exploration 👩‍🔬✨ of best practices for Compose, design systems, testing, modularization, linting & enforcement of best practices, Gradle config, build speeds, CI, etc.


### PR DESCRIPTION
Add a badge for CI status, and updates the Figma badge to be the same size.

Before:
<img width="285" alt="image" src="https://user-images.githubusercontent.com/68218/218293268-c2ed99e8-1f34-49f6-b32d-7e034cc0fc00.png">

After:
<img width="391" alt="image" src="https://user-images.githubusercontent.com/68218/218293261-e97a42ee-18c7-4601-ad94-52005cdb795a.png">
